### PR TITLE
feat: add one-command Go protobuf generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmake-build-*
 .idea
+gen/go/

--- a/README.md
+++ b/README.md
@@ -8,10 +8,18 @@
 
 ## 生成 Go protobuf
 
-如果你想在 Go 项目里直接使用这个仓库的 proto，可以执行下面的脚本一键生成：
+如果你想在 Go 项目里直接使用这个仓库的 proto，可以执行下面的脚本一键生成。
+
+### Linux / macOS / Git Bash / WSL
 
 ```bash
 bash scripts/gen-go.sh
+```
+
+### Windows PowerShell
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\gen-go.ps1
 ```
 
 生成结果默认输出到：

--- a/README.md
+++ b/README.md
@@ -5,3 +5,32 @@
 
 目前还存在部分问题：
 1. 部分已删除的消息还存在proto中 （没注意到，后续会整理一遍）
+
+## 生成 Go protobuf
+
+如果你想在 Go 项目里直接使用这个仓库的 proto，可以执行下面的脚本一键生成：
+
+```bash
+bash scripts/gen-go.sh
+```
+
+生成结果默认输出到：
+
+```text
+gen/go/
+```
+
+### 依赖
+
+请先安装：
+
+1. `protoc`
+2. `protoc-gen-go`
+
+安装 `protoc-gen-go`：
+
+```bash
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+```
+
+如果你的 `GOBIN` 不在 `PATH` 里，请先把它加入环境变量。

--- a/douyin.proto
+++ b/douyin.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package douyin;
+option go_package = "github.com/Remember-the-past/douyin_proto/gen/go;douyin";
 
 message Webcast {
 

--- a/scripts/gen-go.ps1
+++ b/scripts/gen-go.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir '..')
+$OutDir = Join-Path $RootDir 'gen/go'
+$ProtoFile = Join-Path $RootDir 'douyin.proto'
+
+if (-not (Get-Command protoc -ErrorAction SilentlyContinue)) {
+    Write-Error 'protoc is not installed. Please install protoc first.'
+}
+
+if (-not (Get-Command protoc-gen-go -ErrorAction SilentlyContinue)) {
+    Write-Error 'protoc-gen-go is not installed. Install it with: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest'
+}
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+& protoc `
+  --proto_path="$RootDir" `
+  --go_out="$OutDir" `
+  --go_opt=paths=source_relative `
+  "$ProtoFile"
+
+Write-Host "Go protobuf files generated in $OutDir"

--- a/scripts/gen-go.sh
+++ b/scripts/gen-go.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${ROOT_DIR}/gen/go"
+PROTO_FILE="${ROOT_DIR}/douyin.proto"
+
+if ! command -v protoc >/dev/null 2>&1; then
+  echo "Error: protoc is not installed." >&2
+  echo "Please install protoc first." >&2
+  exit 1
+fi
+
+if ! command -v protoc-gen-go >/dev/null 2>&1; then
+  echo "Error: protoc-gen-go is not installed." >&2
+  echo "Install it with: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest" >&2
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+protoc \
+  --proto_path="${ROOT_DIR}" \
+  --go_out="${OUT_DIR}" \
+  --go_opt=paths=source_relative \
+  "${PROTO_FILE}"
+
+echo "Go protobuf files generated in ${OUT_DIR}"


### PR DESCRIPTION
## Summary

This PR adds a simple one-command workflow for generating Go protobuf code from the existing `douyin.proto` file.

## Changes

- add `option go_package` to `douyin.proto`
- add `scripts/gen-go.sh` for one-command Go protobuf generation
- update `README.md` with Go generation instructions
- ignore generated output under `gen/go/`

## Why

This repository is already very useful as a source of Douyin live protobuf definitions.
For Go users, a small built-in generation workflow makes it much easier to consume directly.

After this change, downstream users can simply:

```bash
bash scripts/gen-go.sh
```

and get generated Go protobuf files without rebuilding the command manually every time.

## Notes

This PR intentionally keeps the change minimal and does not alter the existing proto structure beyond adding `go_package`, which is required for smooth Go code generation.
